### PR TITLE
OSX Unity editor library load and support for mesh in quads.

### DIFF
--- a/Runtime/Plugins/AssimpNet/AssimpUnity.cs
+++ b/Runtime/Plugins/AssimpNet/AssimpUnity.cs
@@ -81,7 +81,7 @@ namespace Assimp
             //First time initialization, need to set a probing path (at least in editor) to resolve the native dependencies
             string pluginsFolder = Path.Combine(Application.dataPath, "Plugins");
 #if UNITY_EDITOR
-            string editorPluginNativeFolder = Path.Combine(Path.GetFullPath(string.Format($"Assets/{packageName}")), "Runtime", "Plugins", "AssimpNet", "Native");
+            string editorPluginNativeFolder = Path.Combine(Path.GetFullPath(string.Format($"Packages/{packageName}")), "Runtime", "Plugins", "AssimpNet", "Native");
 #endif
             string native64LibPath = null;
             string native32LibPath = null;

--- a/Runtime/Scripts/MeshImporter.cs
+++ b/Runtime/Scripts/MeshImporter.cs
@@ -72,7 +72,7 @@ namespace UnityMeshImporter
             {
                 foreach (var m in scene.Materials)
                 {
-                    UnityEngine.Material uMaterial = new UnityEngine.Material(Shader.Find("Standard"));
+                    UnityEngine.Material uMaterial = new UnityEngine.Material(Shader.Find("Universal Render Pipeline/Lit"));
 
                     // Albedo
                     if (m.HasColorDiffuse)
@@ -160,12 +160,19 @@ namespace UnityMeshImporter
                         foreach (var f in m.Faces)
                         {
                             // Ignore non-triangle faces
-                            if (f.IndexCount != 3)
+                            if (f.IndexCount != 3 && f.IndexCount != 4)
                                 continue;
 
                             uIndices.Add(f.Indices[2]);
                             uIndices.Add(f.Indices[1]);
                             uIndices.Add(f.Indices[0]);
+
+                            if (f.IndexCount == 4)
+                            {
+                                uIndices.Add(f.Indices[0]);
+                                uIndices.Add(f.Indices[3]);
+                                uIndices.Add(f.Indices[2]);
+                            }
                         }
                     }
 

--- a/Runtime/Scripts/MeshImporter.cs
+++ b/Runtime/Scripts/MeshImporter.cs
@@ -59,6 +59,10 @@ namespace UnityMeshImporter
             if(!File.Exists(meshPath))
                 return null;
 
+            #if UNITY_EDITOR // It is possible the library is not loaded when calling from ExecuteInEditModeScript.
+            AssimpUnity.InitializePlugin();
+            #endif
+
             AssimpContext importer = new AssimpContext();
             Scene scene = importer.ImportFile(meshPath);
             if (scene == null)

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "displayName": "Unity Mesh Importer",
     "name": "com.donghok.meshimporter",
     "unity": "2019.2",
-    "version": "0.1.1",
+    "version": "0.1.2",
     "dependencies": {},
     "keywords": [
         "Mesh",


### PR DESCRIPTION
I have made some minor changes. You can consider merging to the library.
The Assimp library was trying to load `libassimp.dylib` on OSX editor instead of `.bundle`. This was done in `AssimpUnity.cs` but the code was never being called. I fixed that issue and added some `#defines` fix compile errors that I was getting on some platforms.
I also made a small change in `MeshImporter.cs` to load quads in the mesh as 2 triangles.  

Tested with Unity 2019.4.0f1 [OSX 10.14.6]
